### PR TITLE
fixed boilerplate with addon infos

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -9,8 +9,15 @@ import bpy
 
 bl_info = {
     "name": "AI Upscaler for Blender",
-    "version": (2, 0, 0),
-    "blender": (2, 93, 0)
+    "author": "jarrellmark",
+    "version": (2, 0, 1),
+    "blender": (3, 6, 0),
+    "location": "Properties Editor > Output tab > AI Upscaler panel",
+    "description": "Implementation of Real-ESRGAN upscaler to reduce render times by rendering at lower resolution and then upscaling.",
+    "warning": "",
+    "doc_url": "https://github.com/jarrellmark/ai_upscaler_for_blender",
+    "tracker_url": "https://github.com/jarrellmark/ai_upscaler_for_blender/issues",
+    "category": "Render",
 }
 
 ai_upscaler_properties = {


### PR DESCRIPTION
Images being worth thousand words; it makes the addon looks from this:

![image](https://github.com/jarrellmark/ai_upscaler_for_blender/assets/16049822/2312c186-859c-4724-9452-bb1b4dbdfe22)

To this: 

![image](https://github.com/jarrellmark/ai_upscaler_for_blender/assets/16049822/6bca40b3-e3f8-478f-ac41-913ff8febbc2)

A lot more cleaner and user friendly UI.